### PR TITLE
Bugfix: Discord spoilers aren't included on the final guess if the game was lost

### DIFF
--- a/src/lib/game.test.ts
+++ b/src/lib/game.test.ts
@@ -179,4 +179,21 @@ describe("generateEmojiArt", () => {
       🟩🟩🟩"
     `);
   });
+
+  test("includes all rows if Discord spoilers and no solution was found", () => {
+    expect(
+      generateEmojiArt(0, "xyz", ["abc", "def", "ghi", "jkl", "mno"], {
+        discord: true,
+        guessMode: GuessMode.Normal,
+        name: "Wate",
+      })
+    ).toMatchInlineSnapshot(`
+      "Wate 1 X/5
+      ⬛⬛⬛ ||\`ABC\`||
+      ⬛⬛⬛ ||\`DEF\`||
+      ⬛⬛⬛ ||\`GHI\`||
+      ⬛⬛⬛ ||\`JKL\`||
+      ⬛⬛⬛ ||\`MNO\`||"
+    `);
+  });
 });

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -93,11 +93,11 @@ export function generateEmojiArt(
       result += x === State.Correct ? "🟩" : x === State.Present ? "🟨" : "⬛";
     }
     
-    // If we've won, we can stop building the result. This allows for
-    // the final guess to be included as a spoiler if it was incorrect.
-    if (rowStates.every((s) => s === State.Correct)) break;
-    if (discord) result += ` ||\`${row.toUpperCase()}\`||`;
-    if (i < rows.length - 1) result += "\n";
+    // Only include Discord spoilers and new lines if we haven't won yet
+    if (!rowStates.every((s) => s === State.Correct)) {
+      if (discord) result += ` ||\`${row.toUpperCase()}\`||`;
+      if (i < ROW_COUNT - 1) result += "\n";
+    }
   }
   return result;
 }

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -88,15 +88,16 @@ export function generateEmojiArt(
   const count = gameLost(solution, rows) ? "X" : rows.length;
   let result = `${name}${medals} ${gameDay + 1} ${count}/${ROW_COUNT}\n`;
   for (const [i, row] of rows.entries()) {
-    const rowStates = findRowStates(solution, row);
-    for (const x of rowStates) {
+    for (const x of findRowStates(solution, row)) {
       result += x === State.Correct ? "🟩" : x === State.Present ? "🟨" : "⬛";
     }
     
-    // Only include Discord spoilers and new lines if we haven't won yet
-    if (!rowStates.every((s) => s === State.Correct)) {
-      if (discord) result += ` ||\`${row.toUpperCase()}\`||`;
-      if (i < ROW_COUNT - 1) result += "\n";
+    // Only include Discord spoilers if we haven't won yet
+    if (discord && row !== solution) {
+      result += ` ||\`${row.toUpperCase()}\`||`;
+    }
+    if (i < rows.length - 1) {
+      result += "\n";
     }
   }
   return result;

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -87,15 +87,17 @@ export function generateEmojiArt(
   const medals = guessModeMedal(guessMode);
   const count = gameLost(solution, rows) ? "X" : rows.length;
   let result = `${name}${medals} ${gameDay + 1} ${count}/${ROW_COUNT}\n`;
-  for (let i = 0; i < rows.length; ++i) {
-    const row = rows[i];
-    for (const x of findRowStates(solution, row)) {
+  for (const [i, row] of rows.entries()) {
+    const rowStates = findRowStates(solution, row);
+    for (const x of rowStates) {
       result += x === State.Correct ? "🟩" : x === State.Present ? "🟨" : "⬛";
     }
-    if (i < rows.length - 1) {
-      if (discord) result += ` ||\`${row.toUpperCase()}\`||`;
-      result += "\n";
-    }
+    
+    // If we've won, we can stop building the result. This allows for
+    // the final guess to be included as a spoiler if it was incorrect.
+    if (rowStates.every((s) => s === State.Correct)) break;
+    if (discord) result += ` ||\`${row.toUpperCase()}\`||`;
+    if (i < rows.length - 1) result += "\n";
   }
   return result;
 }


### PR DESCRIPTION
This resolves the bug for those who might lose a game of Wordy, leaving them nowhere to hide their shame.

### Context

Don't ask how I discovered this, but hypothetically if you were to lose a game of Wordy and you wanted to share the result (for some reason) with Discord spoilers, the last guess of the game would not include the spoiler despite it not being the correct answer.

### Fix

Before including each spoiler and new line in the Emoji art, the guess is checked for victory, rather than relying implicitly on the guess count.